### PR TITLE
Add support for RedHat distros (and Nobara)

### DIFF
--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,4 +1,4 @@
 pip==23.1
 ansible==7.4.0
 yamllint==1.31.0
-ansible-lint==6.15.0
+#ansible-lint==6.15.1.dev22

--- a/.github/workflows/constraints.txt
+++ b/.github/workflows/constraints.txt
@@ -1,4 +1,4 @@
 pip==23.1
 ansible==7.4.0
 yamllint==1.31.0
-#ansible-lint==6.15.1.dev22
+ansible-lint==6.16.2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,11 +43,15 @@ jobs:
     strategy:
       matrix:
         distro:
-          - debian11 # Bullseye
-          - debian10 # Buster
-          - ubuntu2204 # Jammy
+          # Bullseye
+          - debian11
+          # Buster
+          - debian10
+          # Jammy
+          - ubuntu2204
           # https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
-          - ubuntu2004 # Focal
+          # Focal
+          - ubuntu2004
           - fedora38
           - fedora37
           - centos8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,15 +43,11 @@ jobs:
     strategy:
       matrix:
         distro:
-          # Bullseye
-          - debian11
-          # Buster
-          - debian10
-          # Jammy
-          - ubuntu2204
+          - debian11  # Bullseye
+          - debian10  # Buster
+          - ubuntu2204  # Jammy
           # https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
-          # Focal
-          - ubuntu2004
+          - ubuntu2004  # Focal
           - fedora38
           - fedora37
           - centos8

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install test dependencies
-        # TODO: WWhen there is an ansible-lint release above 6.15.0 constrain it and install it through PyPI
+        # TODO: When there is an ansible-lint release above 6.15.0 constrain it and install it through PyPI
         run: pip install --constraint=.github/workflows/constraints.txt ansible yamllint git+https://github.com/ansible/ansible-lint
 
       - name: Lint code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,8 +45,8 @@ jobs:
         distro:
           - debian11  # Bullseye
           - debian10  # Buster
-          - ubuntu2204  # Jammy
           # https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
+          # - ubuntu2204  # Jammy
           - ubuntu2004  # Focal
           - fedora38
           - fedora37

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,8 @@ jobs:
           python-version: "3.10"
 
       - name: Install test dependencies
-        run: pip install --constraint=.github/workflows/constraints.txt ansible yamllint ansible-lint
+        # TODO: WWhen there is an ansible-lint release above 6.15.0 constrain it and install it through PyPI
+        run: pip install --constraint=.github/workflows/constraints.txt ansible yamllint git+https://github.com/ansible/ansible-lint
 
       - name: Lint code
         run: |
@@ -45,8 +46,7 @@ jobs:
         distro:
           - debian11  # Bullseye
           - debian10  # Buster
-          # https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
-          # - ubuntu2204  # Jammy
+          - ubuntu2204  # Jammy
           - ubuntu2004  # Focal
           - fedora38
           - fedora37

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,8 +29,7 @@ jobs:
           python-version: "3.10"
 
       - name: Install test dependencies
-        # TODO: When there is an ansible-lint release above 6.15.0 constrain it and install it through PyPI
-        run: pip install --constraint=.github/workflows/constraints.txt ansible yamllint git+https://github.com/ansible/ansible-lint
+        run: pip install --constraint=.github/workflows/constraints.txt ansible yamllint ansible-lint
 
       - name: Lint code
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,11 +43,34 @@ jobs:
     strategy:
       matrix:
         distro:
-          - debian11
-          - debian10
+          - debian11 # Bullseye
+          - debian10 # Buster
+          - debian9 # Stretch
+          - debian8 # Jessie
+          - ubuntu2204 # Jammy
           # https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
-          # - ubuntu2204
-          - ubuntu2004
+          - ubuntu2004 # Focal
+          - ubuntu1804 # Bionic
+          - ubuntu1604 # Xenial
+          - ubuntu1404 # Trusty  # archive
+          - ubuntu1204 # Precise # archive
+          - fedora38
+          - fedora37
+          - fedora36
+          - fedora35
+          - fedora33
+          - fedora34
+          - fedora32
+          - fedora31
+          - fedora30
+          - fedora29
+          - fedora27
+          - fedora24 # archive
+          - centos8
+          - centos7
+          - centos6
+          - rockylinux9
+          - rockylinux8
 
     steps:
       - name: Check out the repository

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,30 +45,12 @@ jobs:
         distro:
           - debian11 # Bullseye
           - debian10 # Buster
-          - debian9 # Stretch
-          - debian8 # Jessie
           - ubuntu2204 # Jammy
           # https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
           - ubuntu2004 # Focal
-          - ubuntu1804 # Bionic
-          - ubuntu1604 # Xenial
-          - ubuntu1404 # Trusty  # archive
-          - ubuntu1204 # Precise # archive
           - fedora38
           - fedora37
-          - fedora36
-          - fedora35
-          - fedora33
-          - fedora34
-          - fedora32
-          - fedora31
-          - fedora30
-          - fedora29
-          - fedora27
-          - fedora24 # archive
           - centos8
-          - centos7
-          - centos6
           - rockylinux9
           - rockylinux8
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Extensions are installed but need to be manually enabled from Firefox.
 ## Requirements
 
 [requests] is required on the remote host to install extensions.
+The OS of the remote host is supported, see [ansible-galaxy staticdev/firefox].
 
 ## Role Variables
 
@@ -68,3 +69,4 @@ This Ansible role is a modified version of the [ansible-firefox] originally crea
 [requests]: https://docs.python-requests.org/en/master
 [staticdev]: https://github.com/staticdev
 [unrblt]: https://github.com/unrblt
+[ansible-galaxy staticdev/firefox]: https://galaxy.ansible.com/staticdev/firefox

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,10 +19,10 @@ galaxy_info:
 
     - name: Fedora
       versions:
-        # yamllint disable rule_id=schema[meta]
+        # yamllint disable
         - "38"
         - "37"
-        # yamllint enable rule_id=schema[meta]
+        # yamllint enable
 
     - name: EL
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,8 +19,10 @@ galaxy_info:
 
     - name: Fedora
       versions:
+        # yamllint disable rule_id=schema[meta]
         - "38"
         - "37"
+        # yamllint enable rule_id=schema[meta]
 
     - name: EL
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,49 +11,39 @@ galaxy_info:
       versions:
         - bullseye
         - buster
+        - stretch
+        - jessie
 
     - name: Ubuntu
       versions:
-        # - jammy
+        - jammy
         - focal
-
-    - name: Nobara
-      versions:
-        - "37"
-        - "36"
+        - bionic
+        - xenial
+        - trusty # archive
+        - precise # archive
 
     - name: Fedora
       versions:
-        - "39" # rawhide
         - "38"
         - "37"
         - "36"
+        - "35"
+        - "33"
+        - "34"
+        - "32"
+        - "31"
+        - "30"
+        - "29"
+        - "27"
+        - "24" # archive
 
-    - name: Oracle Linux
+    - name: EL
       versions:
         - "9"
         - "8"
         - "7"
-
-    - name: Rocky Linux
-      versions:
-        - "9"
-        - "8"
-
-    - name: Alma Linux
-      versions:
-        - "9"
-        - "8"
-
-    - name: CentOS
-      versions:
-        - "7"
-        - "8"
-
-    - name: CentOS Stream
-      versions:
-        - "9"
-        - "8"
+        - "6"
 
   galaxy_tags:
     - workstation

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
 
     - name: Ubuntu
       versions:
-        #- jammy
+        # - jammy
         - focal
 
     - name: Fedora

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
 
     - name: Ubuntu
       versions:
-        - jammy
+        #- jammy
         - focal
 
     - name: Fedora

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,15 +14,13 @@ galaxy_info:
 
     - name: Ubuntu
       versions:
-        # - jammy
+        - jammy
         - focal
 
     - name: Fedora
       versions:
-        # yamllint disable
         - "38"
         - "37"
-        # yamllint enable
 
     - name: EL
       versions:

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,39 +11,21 @@ galaxy_info:
       versions:
         - bullseye
         - buster
-        - stretch
-        - jessie
 
     - name: Ubuntu
       versions:
         - jammy
         - focal
-        - bionic
-        - xenial
-        - trusty # archive
-        - precise # archive
 
     - name: Fedora
       versions:
         - "38"
         - "37"
-        - "36"
-        - "35"
-        - "33"
-        - "34"
-        - "32"
-        - "31"
-        - "30"
-        - "29"
-        - "27"
-        - "24" # archive
 
     - name: EL
       versions:
         - "9"
         - "8"
-        - "7"
-        - "6"
 
   galaxy_tags:
     - workstation

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,44 @@ galaxy_info:
         # - jammy
         - focal
 
+    - name: Nobara
+      versions:
+        - "37"
+        - "36"
+
+    - name: Fedora
+      versions:
+        - "39" # rawhide
+        - "38"
+        - "37"
+        - "36"
+
+    - name: Oracle Linux
+      versions:
+        - "9"
+        - "8"
+        - "7"
+
+    - name: Rocky Linux
+      versions:
+        - "9"
+        - "8"
+
+    - name: Alma Linux
+      versions:
+        - "9"
+        - "8"
+
+    - name: CentOS
+      versions:
+        - "7"
+        - "8"
+
+    - name: CentOS Stream
+      versions:
+        - "9"
+        - "8"
+
   galaxy_tags:
     - workstation
     - system

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -14,19 +14,10 @@
         cache_valid_time: 600
       when: ansible_os_family == 'Debian'
 
-    - name: Ensure Debian dependencies are installed
-      ansible.builtin.apt:
+    - name: Ensure dependencies are installed
+      ansible.builtin.package:
         name: "{{ item }}"
         state: present
-      when: ansible_distribution == 'Debian'
-      with_items:
-        - python3-requests
-
-    - name: Ensure Ubuntu dependencies are installed
-      ansible.builtin.apt:
-        name: "{{ item }}"
-        state: present
-      when: ansible_distribution == 'Ubuntu'
       with_items:
         - python3-requests
 

--- a/molecule/default/daemon.json
+++ b/molecule/default/daemon.json
@@ -1,0 +1,3 @@
+{ 
+    "default-cgroupns-mode": "host"
+}

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,32 +4,12 @@ dependency:
 driver:
   name: podman
 platforms:
-  - name: debian
-    # bullseye / 11
+  - name: instance
     image: "docker.io/geerlingguy/docker-${MOLECULE_DISTRO:-debian11}-ansible:latest"
     command: ${MOLECULE_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
-
-  - name: ubuntu
-    # focal
-    image: "docker.io/geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
-    command: ${MOLECULE_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
-
-  - name: fedora
-    # 37
-    image: "docker.io/geerlingguy/docker-${MOLECULE_DISTRO:-fedora37}-ansible:latest"
-    command: ${MOLECULE_COMMAND:-""}
-    volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
-    privileged: true
-    pre_build_image: true
-
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -4,12 +4,32 @@ dependency:
 driver:
   name: podman
 platforms:
-  - name: instance
+  - name: debian
+    # bullseye / 11
     image: "docker.io/geerlingguy/docker-${MOLECULE_DISTRO:-debian11}-ansible:latest"
     command: ${MOLECULE_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
     privileged: true
     pre_build_image: true
+
+  - name: ubuntu
+    # focal
+    image: "docker.io/geerlingguy/docker-${MOLECULE_DISTRO:-ubuntu2004}-ansible:latest"
+    command: ${MOLECULE_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+
+  - name: fedora
+    # 37
+    image: "docker.io/geerlingguy/docker-${MOLECULE_DISTRO:-fedora37}-ansible:latest"
+    command: ${MOLECULE_COMMAND:-""}
+    volumes:
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    privileged: true
+    pre_build_image: true
+
 provisioner:
   name: ansible

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -9,6 +9,8 @@ platforms:
     command: ${MOLECULE_COMMAND:-""}
     volumes:
       - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      # https://github.com/geerlingguy/docker-ubuntu2204-ansible/issues/6
+      - ${MOLECULE_SCENARIO_DIRECTORY}/daemon.json:/etc/docker/daemon.json
     privileged: true
     pre_build_image: true
 provisioner:

--- a/tasks/apt-ubuntu2204+.yml
+++ b/tasks/apt-ubuntu2204+.yml
@@ -40,7 +40,7 @@
 - name: Install Firefox
   ansible.builtin.apt:
     name: "{{ firefox_package_name }}"
-    state: latest
+    state: present
     allow_downgrade: true
   become: true
   when: "'snap' in ansible_facts.packages['firefox'][0].version"

--- a/tasks/apt-ubuntu2204+.yml
+++ b/tasks/apt-ubuntu2204+.yml
@@ -1,0 +1,46 @@
+---
+# https://www.omgubuntu.co.uk/2022/04/how-to-install-firefox-deb-apt-ubuntu-22-04
+
+- name: Install dirmngr
+  ansible.builtin.package:
+    name: dirmngr
+    state: present
+  become: true
+
+- name: Add Mozilla Firefox PPA Repository
+  ansible.builtin.apt_repository:
+    repo: ppa:mozillateam/ppa
+  become: true
+
+- name: Configure Mozilla Firefox PPA priority
+  ansible.builtin.copy:
+    dest: /etc/apt/preferences.d/mozilla-firefox
+    content: |
+      Package: *
+      Pin: release o=LP-PPA-mozillateam
+      Pin-Priority: 1001
+    owner: root
+    group: root
+    mode: '0644'
+  become: true
+
+# - name: Configure unattended upgrades for Mozilla Firefox PPA
+#   ansible.builtin.copy:
+#     dest: /etc/apt/apt.conf.d/51unattended-upgrades-firefox
+#     content: |
+#       Unattended-Upgrade::Allowed-Origins:: "LP-PPA-mozillateam:{{ ansible_distribution_codename }}";
+#     owner: root
+#     group: root
+#     mode: '0444'
+#   become: true
+
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+
+- name: Install Firefox
+  ansible.builtin.apt:
+    name: "{{ firefox_package_name }}"
+    state: latest
+    allow_downgrade: true
+  become: true
+  when: "'snap' in ansible_facts.packages['firefox'][0].version"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,6 +14,7 @@
   ansible.builtin.package:
     name: "{{ firefox_package_name }}"
     state: present
+  become: true
 
 - name: Configure profiles
   ansible.builtin.include_tasks: configure_profile.yml

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,16 @@
     state: present
   become: true
 
+- name: Gather the package facts
+  ansible.builtin.package_facts:
+  when: "ansible_distribution == 'Ubuntu'"
+
+- name: Install Firefox for ubuntu2204+ using apt
+  ansible.builtin.include_tasks: apt-ubuntu2204+.yml
+  when: "ansible_distribution == 'Ubuntu' and 'snap' in ansible_facts.packages['firefox'][0].version"
+
+# TODO: Add install option for ubuntu2204+ using snap
+
 - name: Configure profiles
   ansible.builtin.include_tasks: configure_profile.yml
   with_dict: "{{ firefox_profiles }}"

--- a/vars/Nobara.yml
+++ b/vars/Nobara.yml
@@ -1,0 +1,3 @@
+---
+firefox_package_name:
+  - firefox

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -1,0 +1,3 @@
+---
+firefox_package_name:
+  - firefox


### PR DESCRIPTION
It might even be a good idea to set `firefox_package_name: firefox` as a default for any other distros than Debian [because most use Firefox](https://pkgs.org/download/firefox).